### PR TITLE
feat: generate ng-packagr flattenModuleId on root package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 coverage
+/.idea

--- a/__tests__/app.js
+++ b/__tests__/app.js
@@ -4,6 +4,7 @@ const { EventEmitter } = require('events');
 const fs = require('fs-extra');
 const assert = require('yeoman-assert');
 const helpers = require('yeoman-test');
+const Generator = require("../generators/app");
 const { createSandbox } = require('sinon');
 
 const sandbox = createSandbox();
@@ -409,4 +410,15 @@ describe('generator-console-package:app:@console-plugin', () => {
 
     expect(mockSpawn.callCount).toBe(2);
   });
+});
+
+describe('flattenModuleId', () => {
+  const testcases = [
+    ['foo', 'bar', 'foo-bar'],
+    [undefined, 'bar/qux', 'bar-qux'],
+    ['foo', 'bar/qux', 'foo-bar-qux']
+  ];
+  it.each(testcases)("flattenModuleId(%s, %s) should return %s", (scope, packageName, expected) => {
+    expect(Generator.flattenModuleId(scope, packageName)).toBe(expected);
+  })
 });

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -81,6 +81,13 @@ module.exports = class extends Generator {
     );
     const { packageName } = this.props;
 
+    // generate flat module id
+    // For design, @see https://github.com/ng-packagr/ng-packagr/blob/v4.4.1/docs/DESIGN.md#tools-and-implementation-details
+    // For implementation, @see https://github.com/ng-packagr/ng-packagr/blob/v4.4.1/src/lib/ng-package-format/entry-point.ts#L157
+    Object.assign(this.props, {
+      flattenModuleId: Generator.flattenModuleId(scope, packageName)
+    });
+
     // module name
     Object.assign(
       this.props,
@@ -234,3 +241,11 @@ module.exports = class extends Generator {
     });
   }
 };
+
+Generator.flattenModuleId = function (scope, packageName) {
+  const separator = "-";
+  if (scope !== undefined) {
+    return [scope].concat(packageName.split("/")).join(separator);
+  }
+  return packageName.split("/").join(separator);
+}

--- a/generators/app/templates/library/README.md
+++ b/generators/app/templates/library/README.md
@@ -20,12 +20,6 @@ yarn link <%= scope %>/<%= packageName %>
 
 ## publish
 
-`lerna publish` 暂时无法用来发布 Angular Package, 你可以使用以下方式进行发布：
-
 ```
-lerna publish --scope=<%= scope %>/<%= packageName %> --skip-npm
-lerna run build --scope=<%= scope %>/<%= packageName %>
-lerna exec --scope=<%= scope %>/<%= packageName %> npm publish ./dist -- --registry=https://registry.npm.easyops.local
+lerna publish
 ```
-
-注意，与`lerna publish` 不同，`npm publish` 是直接把当前目录发布到注册表中，因此需要先调用`lerna publish`的能力进行版本确定，但是跳过 npm 发布阶段，然后再单独执行`npm publish ./dist`发布 `ng-packagr` 生成的包。

--- a/generators/app/templates/library/package.json.ejs
+++ b/generators/app/templates/library/package.json.ejs
@@ -2,7 +2,6 @@
   "name": "<%= scope %>/<%= packageName %>",
   "version": "0.0.0",
   "main": "dist/bundles/<%= flattenModuleId %>.umd.js",
-  "types": "public_api.ts",
   "repository": "https://git.easyops.local/anyclouds/<%= repository %>",
   "license": "UNLICENSED",
   "files": ["dist/"],

--- a/generators/app/templates/library/package.json.ejs
+++ b/generators/app/templates/library/package.json.ejs
@@ -1,17 +1,17 @@
 {
   "name": "<%= scope %>/<%= packageName %>",
   "version": "0.0.0",
-  "main": "public_api.ts",
+  "main": "dist/bundles/<%= flattenModuleId %>.umd.js",
   "types": "public_api.ts",
   "repository": "https://git.easyops.local/anyclouds/<%= repository %>",
   "license": "UNLICENSED",
-  "files": ["dist"],
+  "files": ["dist/"],
   "scripts": {
 <% if (!removeScriptsStart) { %>
     "start": "ng-packagr -w -p package.json",
 <% } %>
     "prebuild": "rimraf dist",
-    "build": "ng-packagr -p package.json",
+    "build": "ng-packagr -p package.json && rimraf dist/package.json",
     "prepublishOnly": "npm run build",
     "postprebulishOnly": "cd dist"
   },
@@ -23,5 +23,13 @@
   "peerDependencies": {
     "@angular/common": "^6.0.3",
     "@angular/core": "^6.0.3"
-  }
+  },
+  "module": "dist/fesm5/<%= flattenModuleId %>.js",
+  "es2015": "dist/fesm2015/<%= flattenModuleId %>.js",
+  "esm5": "dist/esm5/<%= flattenModuleId %>.js",
+  "esm2015": "dist/esm2015/<%= flattenModuleId %>.js",
+  "fesm5": "dist/fesm5/<%= flattenModuleId %>.js",
+  "fesm2015": "dist/fesm2015/<%= flattenModuleId %>.js",
+  "typings": "dist/<%= flattenModuleId %>.d.ts",
+  "metadata": "dist/<%= flattenModuleId %>.metadata.json"
 }

--- a/generators/app/templates/library/package.json.ejs
+++ b/generators/app/templates/library/package.json.ejs
@@ -11,8 +11,7 @@
 <% } %>
     "prebuild": "rimraf dist",
     "build": "ng-packagr -p package.json && rimraf dist/package.json",
-    "prepublishOnly": "npm run build",
-    "postprebulishOnly": "cd dist"
+    "prepublishOnly": "npm run build"
   },
   "ngPackage": {
     "lib": {
@@ -30,5 +29,6 @@
   "fesm5": "dist/fesm5/<%= flattenModuleId %>.js",
   "fesm2015": "dist/fesm2015/<%= flattenModuleId %>.js",
   "typings": "dist/<%= flattenModuleId %>.d.ts",
-  "metadata": "dist/<%= flattenModuleId %>.metadata.json"
+  "metadata": "dist/<%= flattenModuleId %>.metadata.json",
+  "sideEffects": false
 }


### PR DESCRIPTION
INFRA-9

So that we can run `npm publish` directly on the ng-packaged root. This is an opinionated workaround of https://github.com/lerna/lerna/issues/1282.